### PR TITLE
Fix `IntersectionObserver` for Safari.

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -74,6 +74,10 @@ window.addEventListener
 
 // System/browser theme change listener
 
+if (!system_dark_theme.addEventListener)
+	system_dark_theme.addEventListener =
+		(event, listener) => system_dark_theme.addListener(listener);
+
 system_dark_theme.addEventListener
 (
 	"change",


### PR DESCRIPTION
Create the `addEventListener` using `addListener` on Safari.